### PR TITLE
TP-91178 Only pass valid gpt slots to googletag

### DIFF
--- a/js/manager.js
+++ b/js/manager.js
@@ -375,6 +375,7 @@ const DFPManager = Object.assign(new EventEmitter().setMaxListeners(0), {
     }
     return new Promise((resolve) => {
       const slots = [];
+      const gptSlots = [];
       // eslint-disable-next-line guard-for-in,no-restricted-syntax
       for (const idx in slotsToDestroy) {
         const slotId = slotsToDestroy[idx];
@@ -389,10 +390,12 @@ const DFPManager = Object.assign(new EventEmitter().setMaxListeners(0), {
                 // eslint-disable-next-line guard-for-in,no-restricted-syntax
                 for (const idx in slots) {
                   const slot = slots[idx];
-                  slots.push(slot.gptSlot);
-                  delete slot.gptSlot;
+                  if (slot?.gptSlot) {
+                    gptSlots.push(slot.gptSlot);
+                    delete slot.gptSlot;
+                  }
                 }
-                googletag.destroySlots(slots);
+                googletag.destroySlots(gptSlots);
               } else {
                 googletag.destroySlots();
               }


### PR DESCRIPTION
- The lib was accidentally passing local registry slots to googletag when we should only be passing the native gpt slot to google tag.
- This error was masked in google tag as the destroySlots function is wrapped in a try --> catch.
- However Yieldbird overwrite the native googletag function and remove the try catch exposing this bug.