### PR TITLE
Tp 96560 hubvisor updates

### DIFF
--- a/js/manager.js
+++ b/js/manager.js
@@ -266,6 +266,7 @@ const DFPManager = Object.assign(new EventEmitter().setMaxListeners(0), {
           });
           resolve();
         });
+        this.emit('slotsLoaded', slotsToInitialize);
       });
     });
   },

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -293,6 +293,8 @@ var DFPManager = Object.assign(new _events.EventEmitter().setMaxListeners(0), {
           });
           resolve();
         });
+
+        _this3.emit('slotsLoaded', slotsToInitialize);
       });
     });
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsch/react-dfp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "homepage": "https://github.com/jaanauati/react-dfp/",
   "author": {
     "name": "Jonatan Alexis Anauati",


### PR DESCRIPTION
Dependency for this PR here: https://github.com/distilledmedia/dsch-daft-frontend/pull/3697

This change will not impact the current behaviour of the package once merged. It should only an event at the point where ad slots have have load() and display() called, but not refresh(). This means the slot is ready for content but not yet had a creative received.
We need this for the hubvisor changes as hubvisor is to be in charge of that refresh, but the ads need to be ready before we call it. The current event emitters in the package only fire after register(), which is before load(), or after render or is visible, which is after refresh